### PR TITLE
Highest city spec bug

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,11 @@
 #### What does this PR do?
+#### Migrations
+YES | NO
 #### Where should the reviewer start?
 #### How should this be manually tested?
 #### Any background context you want to provide?
 #### What are the relevant tickets?
 #### Screenshots (if appropriate)
 #### Questions:
-  - Do Migrations Need to be ran?
   - Do Environment Variables need to be set?
   - Any other deploy steps?

--- a/lib/fair_bnb/api_helpers.rb
+++ b/lib/fair_bnb/api_helpers.rb
@@ -50,7 +50,7 @@ module FairBnb
         .joins(:reservations)
         .where(reservations: {start_date: "#{params[:year]}-#{params[:month]}-01"})
         .group("properties.city")
-        .order("revenue DESC")
+        .order("revenue DESC", "properties.city ASC")
         .limit(params[:limit])
         .map(&:city)
     end

--- a/spec/requests/api/v1/reservations/highest_revenue_cities_spec.rb
+++ b/spec/requests/api/v1/reservations/highest_revenue_cities_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 describe 'highest revenue cities endpoint' do
-  attr_reader :cities
+  attr_reader :seed_cities
   before :each do
-    @cities = ["Denver", "Tulsa", "San Francisco",
+    @seed_cities = ["Denver", "Tulsa", "San Francisco",
       "New York", "Boston", "Seattle",
       "Washington D.C.", "Atlanta", "Durham",
       "Los Angeles", "San Antonio", "Portland",
       "Austin", "Nashville", "Raleigh"
     ]
-    cities.each do |city|
+    seed_cities.each do |city|
       create(:property, city: city)
     end
     12.times do |n|
@@ -25,9 +25,11 @@ describe 'highest revenue cities endpoint' do
   end
   context "when user adds a limit, month, and year param" do
     it "returns top X cities by that year and month" do
-      limit = 6; month = 4; year = 2016
+      limit = 6
+      month = 4
+      year = 2016
 
-      city_revenues = find_city_revenue(cities, limit, month, year)
+      city_revenues = find_city_revenue(seed_cities, limit, month, year)
       get "/api/v1/reservations/highest_revenue_cities",
         params: {limit: limit, month: month, year: year}
 

--- a/spec/stub_helper.rb
+++ b/spec/stub_helper.rb
@@ -53,8 +53,6 @@ def find_city_revenue(cities, limit = 10, month = "", year = "")
         .where(city: city)
         .sum('reservations.total_price')
         .limit(limit)
-    # binding.pry
-    # revenue.sort
     end
   elsif (month == "")
     revenue = cities.map do |city|
@@ -75,6 +73,6 @@ def find_city_revenue(cities, limit = 10, month = "", year = "")
         .sum('reservations.total_price')
       t << [city, revenue]; t
     end
-    out.sort_by {|rev| rev[1]}.reverse.take(limit)
+    out.sort{|a,b| (a[1] <=> b[1]) == 0 ? (b[0] <=> a[0]) : (a[1] <=> b[1]) }.reverse.take(limit)
   end
 end


### PR DESCRIPTION
#### What does this PR do?
Fixes the the highest revenue city spec bug.  There was a bug where the last city pulled would not match what was coming from the api.  This was because the cities and the spec cities (to test against were being sorted differently).  I fixed this by ensuring that both the api and the spec cities were being sorted first by revenue then by the city name.  
#### Where should the reviewer start?
`spec/requests/api/v1/highest_revenue_cities.rb` and `spec/stub_helper.rb` and `lib/fair_bnb/api_helper.rb`

#### How should this be manually tested?
the API was working before, the problem was that the spec wouldn't (always) clear  

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran? No
  - Do Environment Variables need to be set? No
  - Any other deploy steps? No
