### PR TITLE
Reservations set to finished automatically

### DIFF
--- a/app/jobs/reservation_to_finished_job.rb
+++ b/app/jobs/reservation_to_finished_job.rb
@@ -1,0 +1,7 @@
+class ReservationToFinishedJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Reservation.where('end_date <  ?', Date.today).update_all(status: 3)
+  end
+end

--- a/lib/tasks/finish_reservations.rake
+++ b/lib/tasks/finish_reservations.rake
@@ -1,0 +1,7 @@
+namespace :fairbnb do
+  desc 'Look for reservations who have an end_date in the past and mark them as status: finished'
+  task finish_reservations: :environment do
+    puts "Marking past reservations as finished"
+    ReservationToFinishedJob.perform_now
+  end
+end

--- a/spec/jobs/reservation_to_finished_job_spec.rb
+++ b/spec/jobs/reservation_to_finished_job_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ReservationToFinishedJob, type: :job do
+  let!(:reservation) { create(:reservation, end_date: Date.yesterday) }
+  it 'sets a past reservation to finished' do
+    expect(reservation.status).to eq 'confirmed'
+    ReservationToFinishedJob.perform_now
+    reservation.reload
+    expect(reservation.status).to eq 'finished'
+  end
+end


### PR DESCRIPTION
#### What does this PR do?
Created ActiveJob and corresponding rake task to automate marking reservations as past.  

#### Migrations
NO  
#### Where should the reviewer start?
`lib/tasks/finish_reservations.rake`

#### How should this be manually tested?
Run `rake fairbnb:finish_reservation` and check db to see that appropriate ones have been marked as finished.

#### Any background context you want to provide?
In server environment, we will still need to setup cron job.

#### What are the relevant tickets?
[#149677607](https://www.pivotaltracker.com/story/show/149677607)

#### Screenshots (if appropriate)
#### Questions:
  - Do Environment Variables need to be set?
  - Any other deploy steps?
