### PR TITLE
Owner can review user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 group :test do
   gem 'vcr'
   gem 'webmock'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,6 +259,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.8.1)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.3)
@@ -321,6 +322,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   shoulda-matchers
   simplecov
+  timecop
   tzinfo-data
   uglifier (>= 1.3.0)
   vcr

--- a/app/controllers/reservations/property_reviews_controller.rb
+++ b/app/controllers/reservations/property_reviews_controller.rb
@@ -7,7 +7,6 @@ class Reservations::PropertyReviewsController < ApplicationController
   end
 
   def create
-    # binding.pry
     if @reservation.create_property_review(review_params)
       redirect_to @reservation.property, success: "Review Successfully Added"
     else

--- a/app/controllers/reservations/user_reviews_controller.rb
+++ b/app/controllers/reservations/user_reviews_controller.rb
@@ -1,0 +1,28 @@
+class Reservations::UserReviewsController < ApplicationController
+
+  before_action :set_reservation, only: [:new, :create]
+
+  def new
+    @user_review = @reservation.build_user_review
+  end
+
+  def create
+    if @reservation.create_user_review(review_params)
+      redirect_to user_property_path(@reservation.property), success: 'Review Successfully Added'
+    else
+      render :new
+    end
+  end
+
+  private
+
+    def set_reservation
+      @reservation = Reservation.find(params[:reservation_id])
+    end
+
+    def review_params
+      params.require(:user_review)
+            .permit(:user_id, :body, :rating)
+            .merge(renter_id: @reservation.renter.id)
+    end
+end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -6,6 +6,7 @@ class Reservation < ApplicationRecord
   belongs_to :property
   belongs_to :renter, class_name: "User", foreign_key: "renter_id"
   has_one :property_review
+  has_one :user_review
 
   enum status: %w(pending confirmed in_progress finished declined)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,13 @@ class User < ApplicationRecord
   devise :omniauthable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :database_authenticatable
 
-  has_many :reservations, foreign_key: "renter_id"
+  has_many :reservations, foreign_key: 'renter_id'
 
-  has_many :properties, foreign_key: "owner_id"
+  has_many :properties, foreign_key: 'owner_id'
   has_many :property_reviews
+  has_many :user_reviews
 
-  enum role: %w(registered_user admin)
+  enum role: %w[registered_user admin]
 
   validates :username, uniqueness: true, allow_nil: true, case_sensitive: false
   validates_format_of :username, with: /\A^[a-zA-Z0-9_\.]*$\z/, multiline: true
@@ -22,15 +23,15 @@ class User < ApplicationRecord
     !properties.empty?
   end
 
-  def is_owner_of?(property)
+  def owner_of?(property)
     properties.includes? property
   end
 
-  def has_reviewed_property?(reservation)
+  def reviewed_property?(reservation)
     reservation.id.in? property_reviews.pluck(:reservation_id)
   end
 
-  def has_reviewed_renter?(request)
+  def reviewed_renter?(request)
     request.id.in? user_reviews.pluck(:reservation_id)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,8 +26,12 @@ class User < ApplicationRecord
     properties.includes? property
   end
 
-  def has_reviewed?(reservation)
+  def has_reviewed_property?(reservation)
     reservation.id.in? property_reviews.pluck(:reservation_id)
+  end
+
+  def has_reviewed_renter?(request)
+    request.id.in? user_reviews.pluck(:reservation_id)
   end
 
   def self.from_omniauth(auth_info)

--- a/app/models/user_review.rb
+++ b/app/models/user_review.rb
@@ -1,0 +1,5 @@
+class UserReview < ApplicationRecord
+  belongs_to :user
+  belongs_to :reservation
+  belongs_to :renter, class_name: "User"
+end

--- a/app/views/reservations/requests/_action_finished.html.erb
+++ b/app/views/reservations/requests/_action_finished.html.erb
@@ -1,1 +1,3 @@
-Review User
+<% if !current_user.has_reviewed_renter?(request) %>
+  <%= link_to "Review Renter", new_reservations_user_review_path(request) %>
+<% end %>

--- a/app/views/reservations/requests/_action_finished.html.erb
+++ b/app/views/reservations/requests/_action_finished.html.erb
@@ -1,3 +1,3 @@
-<% if !current_user.has_reviewed_renter?(request) %>
+<% if !current_user.reviewed_renter?(request) %>
   <%= link_to "Review Renter", new_reservations_user_review_path(request) %>
 <% end %>

--- a/app/views/reservations/reservation_actions/_action_finished.html.erb
+++ b/app/views/reservations/reservation_actions/_action_finished.html.erb
@@ -1,3 +1,3 @@
-<% if !current_user.has_reviewed_property?(reservation) %>
+<% if !current_user.reviewed_property?(reservation) %>
   <%= link_to "Review Property", new_reservations_property_review_path(reservation) %>
 <% end %>

--- a/app/views/reservations/reservation_actions/_action_finished.html.erb
+++ b/app/views/reservations/reservation_actions/_action_finished.html.erb
@@ -1,3 +1,3 @@
-<% if !current_user.has_reviewed?(reservation) %>
+<% if !current_user.has_reviewed_property?(reservation) %>
   <%= link_to "Review Property", new_reservations_property_review_path(reservation) %>
 <% end %>

--- a/app/views/reservations/reservation_actions/_action_pending.html.erb
+++ b/app/views/reservations/reservation_actions/_action_pending.html.erb
@@ -1,17 +1,3 @@
 <div class="btn-group btn-group-lg" role="group">
-  <%= link_to "Approve Request",
-              reservation_path(
-                request,
-                res_action: "confirmed"
-              ),
-              method: :patch,
-              class: "btn btn-success" %>
-  <%= link_to "Decline Request",
-              reservation_path(
-                request,
-                res_action: "declined"
-              ),
-              method: :patch,
-              class: "btn btn-danger" %>
-  <a href="#" class="btn btn-primary">Message User</a>
+  <a href="#" class="btn btn-primary">Message Owner</a>
 </div>

--- a/app/views/reservations/user_reviews/new.html.erb
+++ b/app/views/reservations/user_reviews/new.html.erb
@@ -1,0 +1,15 @@
+<%= form_for [:reservations, @user_review] do |f| %>
+  <%= f.hidden_field :user_id, value: current_user.id %>
+  <p>
+    <%= f.label :body, "Comments" %><br/>
+    <%= f.text_area :body, class: "form-control", rows:"5" %>
+  </p>
+  <p><span class="star-rating star-5">
+    <%= f.radio_button "rating", 1 %><i></i>
+    <%= f.radio_button "rating", 2 %><i></i>
+    <%= f.radio_button "rating", 3 %><i></i>
+    <%= f.radio_button "rating", 4 %><i></i>
+    <%= f.radio_button "rating", 5 %><i></i>
+  </span></p>
+  <%= f.submit "Submit Review" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
   namespace :reservations do
     scope ':reservation_id' do
       resources :property_reviews, only: [:new, :create]
+      resources :user_reviews, only: [:new, :create]
     end
   end
 

--- a/db/migrate/20170730231259_create_user_reviews.rb
+++ b/db/migrate/20170730231259_create_user_reviews.rb
@@ -1,0 +1,13 @@
+class CreateUserReviews < ActiveRecord::Migration[5.0]
+  def change
+    create_table :user_reviews do |t|
+      t.references :user, foreign_key: true
+      t.integer :rating
+      t.string :body
+      t.references :reservation, foreign_key: true
+
+      t.timestamps
+    end
+    add_reference :user_reviews, :renter, references: :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170729213239) do
+ActiveRecord::Schema.define(version: 20170730231259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,19 @@ ActiveRecord::Schema.define(version: 20170729213239) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "user_reviews", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "rating"
+    t.string   "body"
+    t.integer  "reservation_id"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.integer  "renter_id"
+    t.index ["renter_id"], name: "index_user_reviews_on_renter_id", using: :btree
+    t.index ["reservation_id"], name: "index_user_reviews_on_reservation_id", using: :btree
+    t.index ["user_id"], name: "index_user_reviews_on_user_id", using: :btree
+  end
+
   create_table "users", force: :cascade do |t|
     t.string   "first_name"
     t.string   "last_name"
@@ -137,4 +150,6 @@ ActiveRecord::Schema.define(version: 20170729213239) do
   add_foreign_key "property_reviews", "users"
   add_foreign_key "reservations", "properties"
   add_foreign_key "reservations", "users", column: "renter_id"
+  add_foreign_key "user_reviews", "reservations"
+  add_foreign_key "user_reviews", "users"
 end

--- a/spec/factories/user_reviews.rb
+++ b/spec/factories/user_reviews.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :user_review do
+    user nil
+    rating 1
+    body "MyString"
+    reservation nil
+  end
+end

--- a/spec/features/properties/owner_can_view_property_show_spec.rb
+++ b/spec/features/properties/owner_can_view_property_show_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Owner can view properties index' do
       expect(page).to have_css('#finished-requests')
       within ('#finished-requests') do
         expect(page).to have_css("#request-#{finished_request.id}")
-        expect(page).to have_content "Review User"
+        expect(page).to have_content "Review Renter"
       end
       expect(page).to have_css('#declined-requests')
       within ('#declined-requests') do

--- a/spec/features/reviews/owner_can_review_renter_spec.rb
+++ b/spec/features/reviews/owner_can_review_renter_spec.rb
@@ -21,20 +21,19 @@ RSpec.feature 'User can review a property' do
 
         visit user_property_path(property)
 
-        within ('.tab-content #finished-requests') do
-          expect(page).to have_link "Review Renter"
-          click_on "Review Renter"
+        within('.panel#finished-requests') do
+          expect(page).to have_link 'Review Renter'
+          click_on 'Review Renter'
         end
 
-        fill_in "Comments", with: 'Lorem Ipsum'
+        fill_in 'Comments', with: 'Lorem Ipsum'
         choose 'user_review_rating_4'
         click_on 'Submit Review'
 
         expect(current_path).to eq user_property_path(property)
 
-        expect(page).to have_css('#reviews')
-        within ('.tab-content #finished-requests') do
-          expect(page).not_to have_link "Review Renter"
+        within('.panel#finished-requests') do
+          expect(page).not_to have_link 'Review Renter'
         end
       end
     end

--- a/spec/features/reviews/owner_can_review_renter_spec.rb
+++ b/spec/features/reviews/owner_can_review_renter_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.feature 'User can review a property' do
+  context 'when the user has stayed at the property' do
+    let(:user) { create(:user) }
+    let(:owner) { create(:user) }
+    let(:property) { create(:property, owner: owner) }
+    let!(:reservation) { create(:reservation,
+                          renter: user,
+                          status: 3,
+                          property: property
+                        )}
+    let!(:review) { create(:property_review,
+                            property: reservation.property,
+                            rating: 5,
+                            reservation: reservation
+                          )}
+    context 'when the owner has not yet reviewed the renter'do
+      it 'the owner is able to review the renter only once' do
+        login(owner)
+
+        visit user_property_path(property)
+
+        within ('.tab-content #finished-requests') do
+          expect(page).to have_link "Review Renter"
+          click_on "Review Renter"
+        end
+
+        fill_in "Comments", with: 'Lorem Ipsum'
+        choose 'user_review_rating_4'
+        click_on 'Submit Review'
+
+        expect(current_path).to eq user_property_path(property)
+
+        expect(page).to have_css('#reviews')
+        within ('.tab-content #finished-requests') do
+          expect(page).not_to have_link "Review Renter"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/user_review_spec.rb
+++ b/spec/models/user_review_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserReview, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,19 +25,42 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '.has_reviewed?' do
+  describe '.reviewed_property?' do
     let!(:user) { create(:user) }
     let(:reservation) { create(:reservation, renter: user) }
     context 'when there is a reservation with no review' do
       it 'returns false' do
-        expect(user.has_reviewed?(reservation)).to be false
+        expect(user.reviewed_property?(reservation)).to be false
       end
     end
 
     context 'when there is a reservation with a review' do
       let!(:review) { create(:property_review, reservation: reservation, property: reservation.property, user: user) }
       it 'returns true' do
-        expect(user.has_reviewed?(reservation)).to be true
+        expect(user.reviewed_property?(reservation)).to be true
+      end
+    end
+  end
+
+  describe '.reviewed_renter?' do
+    let!(:user) { create(:user) }
+    let!(:owner) { create(:user) }
+    let!(:property) { create(:property, owner: owner) }
+    let!(:reservation) { create(:reservation,
+                          renter: user,
+                          status: 3,
+                          property: property
+                        )}
+    context 'when there is a reservation with no review' do
+      it 'returns false' do
+        expect(owner.reviewed_renter?(reservation)).to be false
+      end
+    end
+
+    context 'when there is a reservation with a review' do
+      let!(:review) { create(:user_review, reservation: reservation, renter: reservation.renter, user: owner) }
+      it 'returns true' do
+        expect(owner.reviewed_renter?(reservation)).to be true
       end
     end
   end

--- a/spec/requests/api/v1/reservations/by_month_request_spec.rb
+++ b/spec/requests/api/v1/reservations/by_month_request_spec.rb
@@ -2,44 +2,48 @@ require 'rails_helper'
 
 describe 'Reservations by month' do
   it 'returns number of reservations for each month' do
+    Timecop.freeze(Time.local(2017, 7, 1, 10, 00, 00)) do
+      reservation1 = create(:reservation, start_date: Date.today)
+      reservation2 = create(:reservation, start_date: Date.today+1.month)
+      reservation3 = create(:reservation, start_date: Date.today+3)
+      reservation4 = create(:reservation, start_date: Date.tomorrow)
 
-    reservation1 = create(:reservation, start_date: Date.today)
-    reservation2 = create(:reservation, start_date: Date.today+30)
-    reservation3 = create(:reservation, start_date: Date.yesterday)
-    reservation4 = create(:reservation, start_date: Date.tomorrow)
+      get "/api/v1/reservations/by_month"
 
-    get "/api/v1/reservations/by_month"
+      expect(response).to be_success
+      reservations = JSON.parse(response.body)
 
-    expect(response).to be_success
-    reservations = JSON.parse(response.body)
+      next_month = (Date.today+1.month).strftime("%B")
 
-    first_month = (Date.today+30).strftime("%B")
-
-    expect(reservations.count).to eq(2)
-    expect(reservations.first['month']).to eq(first_month)
-    expect(reservations.first['count']).to eq(1)
+      expect(reservations.count).to eq(2)
+      expect(reservations.first['month']).to eq(next_month)
+      expect(reservations.first['count']).to eq(1)
+    end
   end
 
   it 'returns number of reservations for each month for a city' do
-    property1 = create(:property, city: 'Denver')
-    property2 = create(:property, city: 'San Francisco')
-    reservation1 = create(:reservation, property_id: property1.id, start_date: Date.today)
-    reservation2 = create(:reservation, property_id: property1.id, start_date: Date.today+30)
-    reservation3 = create(:reservation, property_id: property2.id, start_date: Date.yesterday)
-    reservation4 = create(:reservation, property_id: property1.id, start_date: Date.tomorrow)
+    Timecop.freeze(Time.local(2017, 7, 1, 10, 00, 00)) do
+      property1 = create(:property, city: 'Denver')
+      property2 = create(:property, city: 'San Francisco')
+      reservation_p1_this_month = create(:reservation, property_id: property1.id, start_date: Date.today)
+      reservation_p1_next_month = create(:reservation, property_id: property1.id, start_date: Date.today+1.month)
+      reservation_p1_this_month2 = create(:reservation, property_id: property1.id, start_date: Date.tomorrow)
 
-    get "/api/v1/reservations/by_month?city=Denver"
+      other_property_reservation = create(:reservation, property_id: property2.id, start_date: Date.yesterday)
 
-    expect(response).to be_success
-    reservations = JSON.parse(response.body)
+      get "/api/v1/reservations/by_month?city=Denver"
 
-    first_month = (Date.today+30).strftime("%B")
-    second_month = Date.today.strftime("%B")
+      expect(response).to be_success
+      reservations = JSON.parse(response.body)
 
-    expect(reservations.count).to eq(2)
-    expect(reservations.first['month']).to eq(first_month)
-    expect(reservations.first['count']).to eq(1)
-    expect(reservations.second['month']).to eq(second_month)
-    expect(reservations.second['count']).to eq(2)
+      next_month = (Date.today+1.month).strftime("%B")
+      this_month = Date.today.strftime("%B")
+
+      expect(reservations.count).to eq(2)
+      expect(reservations.first['month']).to eq(next_month)
+      expect(reservations.first['count']).to eq(1)
+      expect(reservations.second['month']).to eq(this_month)
+      expect(reservations.second['count']).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
#### What does this PR do?
Adds the ability of a property owner to review a user (renter) once they have stayed at their property. (One review per reservation)

[Finishes #149453653]

#### Migrations
*YES*

#### Where should the reviewer start?
`spec/features/reviews/owner_can_review_renter_spec.rb`

#### How should this be manually tested?
1. Login as an owner with a property with a finished reservation
2. Navigate to your user_property show page for that property
3. Click on review renter
4. enter review

#### Any background context you want to provide?

#### What are the relevant tickets?
[#149453653](https://www.pivotaltracker.com/story/show/149453653)

#### Screenshots (if appropriate)

#### Questions:
  - Do Environment Variables need to be set?
  - Any other deploy steps? *You will need to `bundle` due to the addition of Timecop.

